### PR TITLE
fix(apps): handle 404 error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0-alpha"
 edition = "2021"
 description = "Blazingly fast Discloud CLI"
 license = "Apache-2.0"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 clap = { version = "3.2.20", features = ["derive"] }

--- a/src/commands/apps.rs
+++ b/src/commands/apps.rs
@@ -1,4 +1,6 @@
 use colored::Colorize;
+
+use crate::entities::FetchError;
 pub fn apps() {
     let token = super::expect_token();
     match crate::entities::app::App::fetch_all(token.clone()) {
@@ -9,7 +11,21 @@ pub fn apps() {
             }
         }
         Err(err) => {
-            super::err(&err.to_string());
+            match err {
+                FetchError::APIReturnedError(code) =>{
+                    match code {
+                        404 => {
+                            super::err("You don't have any apps. Use `discloud up` to upload one.")
+                        }
+                        _ => {
+                            super::err(&err.to_string());
+                        }
+                    }
+                }
+                err => {
+                    super::err(&err.to_string());
+                }
+            }
         }
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -76,7 +76,7 @@ pub fn ask_for_app(token: String, action: &str) -> Result<u128, FetchError> {
     let user = crate::entities::user::fetch_user(token.clone())?;
     match user.apps.len() {
         0 => {
-            err("You don't have any app on discloud, use `discloud up` to upload an app.");
+            err("You don't have any apps. Use `discloud up` to upload one.");
             std::process::exit(1)
         }
         1 => Ok(user.apps[0].parse().unwrap()),


### PR DESCRIPTION
The discloud sends a 404 error when the user doesn't have any apps. This PR checks the error code to show a friendly message.
